### PR TITLE
Change the way the isAlt check is done to support "AltLeft". Also use…

### DIFF
--- a/DragTransfer.js
+++ b/DragTransfer.js
@@ -30,8 +30,8 @@ Hooks.on('dropActorSheetData',(dragTarget,sheet,dragSource,user)=>{
 
   function isAlt(){
      // check if Alt and only Alt is being pressed during the drop event.
-     const alt = new Set(["Alt"]);
-     return (isSuperset(alt,game.keyboard._downKeys) && isSuperset(game.keyboard._downKeys,alt));
+     const alts = new Set(["Alt", "AltLeft"]);
+     return (game.keyboard.downKeys.length == 1 && game.keyboard.downKeys.intersects(alts));
   }
 	
   if (isAlt()) return;  // ignore Drag'N'Transfer when Alt is pressed to drop.

--- a/module.json
+++ b/module.json
@@ -3,12 +3,12 @@
   "title": "Drag'n'Transfer",
   "description": "Move (rather than copy) items drag-and-dropped between character sheets.",
   "author": "David Zvekic",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "compatibleCoreVersion": "0.8.7",
   "minimumCoreVersion": "0.7.9",
   "url":"https://github.com/David-Zvekic/DragTransfer",
-  "manifest": "https://github.com/David-Zvekic/DragTransfer/releases/download/v1.2.1/module.json",
-  "download": "https://github.com/David-Zvekic/DragTransfer/releases/download/v1.2.1/DragTransfer.zip",
+  "manifest": "https://github.com/playest/DragTransfer/releases/download/v1.2.2/module.json",
+  "download": "https://github.com/playest/DragTransfer/releases/download/v1.2.2/DragTransfer.zip",
   "esmodules": ["DragTransfer.js"],
   "languages": [
     {


### PR DESCRIPTION
Change the way the isAlt check is done to support "AltLeft". Also use "downKeys" instead of "\_downKeys" because it will be deprecated in v10.

It was:
```js
  const alt = new Set(["Alt"]);
  return (isSuperset(alt,game.keyboard._downKeys) && isSuperset(game.keyboard._downKeys,alt));
```
which because of the checking with isSuperset in both "directions" would match when _just_ the "alt" key was pressed (which was intended). But it also makes more complex introducing new names for alt keys, like "AltLeft".

It was changed to:
```js
   const alts = new Set(["Alt", "AltLeft"]);
   return (game.keyboard.downKeys.length == 1 && game.keyboard.downKeys.intersects(alts));
```
which as far as I know has the same behavior of working only when _just_ "alt" is pressed (because we check for length == 1) but let us define "other" alt keys.

For the switch from \_downKeys to downKeys it was according to this warning message in the browser console: "Deprecated in favor of \`downKeys\`. Will be removed in V10."