### PR TITLE
Multiple alt key names

### DIFF
--- a/DragTransfer.js
+++ b/DragTransfer.js
@@ -30,8 +30,8 @@ Hooks.on('dropActorSheetData',(dragTarget,sheet,dragSource,user)=>{
 
   function isAlt(){
      // check if Alt and only Alt is being pressed during the drop event.
-     const alt = new Set(["Alt"]);
-     return (isSuperset(alt,game.keyboard._downKeys) && isSuperset(game.keyboard._downKeys,alt));
+     const alts = new Set(["Alt", "AltLeft"]);
+     return (game.keyboard.downKeys.length == 1 && game.keyboard.downKeys.intersects(alts));
   }
 	
   if (isAlt()) return;  // ignore Drag'N'Transfer when Alt is pressed to drop.

--- a/DragTransfer.js
+++ b/DragTransfer.js
@@ -31,7 +31,7 @@ Hooks.on('dropActorSheetData',(dragTarget,sheet,dragSource,user)=>{
   function isAlt(){
      // check if Alt and only Alt is being pressed during the drop event.
      const alts = new Set(["Alt", "AltLeft"]);
-     return (game.keyboard.downKeys.length == 1 && game.keyboard.downKeys.intersects(alts));
+     return (game.keyboard.downKeys.size == 1 && game.keyboard.downKeys.intersects(alts));
   }
 	
   if (isAlt()) return;  // ignore Drag'N'Transfer when Alt is pressed to drop.


### PR DESCRIPTION
Change the way the isAlt check is done to support "AltLeft". Also use "downKeys" instead of "\_downKeys" because it will be deprecated in v10.

It was:
```js
  const alt = new Set(["Alt"]);
  return (isSuperset(alt,game.keyboard._downKeys) && isSuperset(game.keyboard._downKeys,alt));
```
which because of the checking with isSuperset in both "directions" would match when _just_ the "alt" key was pressed (which was intended). But it also makes more complex introducing new names for alt keys, like "AltLeft".

It was changed to:
```js
   const alts = new Set(["Alt", "AltLeft"]);
   return (game.keyboard.downKeys.size == 1 && game.keyboard.downKeys.intersects(alts));
```
which as far as I know has the same behavior of working only when _just_ "alt" is pressed (because we check for length == 1) but let us define "other" alt keys.

For the switch from \_downKeys to downKeys it was according to this warning message in the browser console: "Deprecated in favor of \`downKeys\`. Will be removed in V10."